### PR TITLE
Show google maps thumbnails for listings and homepage

### DIFF
--- a/app/contacto/page.tsx
+++ b/app/contacto/page.tsx
@@ -27,6 +27,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import Image from "next/image";
 import Link from "next/link";
+import { MapThumbnail } from "@/components/MapThumbnail";
 
 export default function ContactoPage() {
   const [contactForm, setContactForm] = useState({
@@ -495,26 +496,26 @@ export default function ContactoPage() {
             transition={{ delay: 0.2 }}
             className="bg-gray-800 rounded-lg p-6 border border-gray-700"
           >
-            <div className="aspect-video bg-gray-700 rounded-lg flex items-center justify-center">
-              <div className="text-center">
-                <MapPin className="w-12 h-12 text-brand-orange mx-auto mb-4" />
-                <p className="text-white font-semibold mb-2">Mapa de Google Maps</p>
-                <p className="text-gray-400 text-sm">Jorge Newbery 1562, Reconquista, Santa Fe</p>
-                <Button
-                  className="mt-4 bg-brand-orange hover:bg-brand-orange/90 text-white"
-                  asChild
-                >
-                  <a
-                    href="https://maps.google.com/?q=Reconquista,+Santa+Fe,+Argentina"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    <Globe className="w-4 h-4 mr-2" />
-                    Ver en Google Maps
-                  </a>
-                </Button>
-              </div>
+            <div className="relative rounded-lg overflow-hidden bg-gray-700">
+              <MapThumbnail 
+                query="Jorge Newbery 1562, Reconquista, Santa Fe, Argentina"
+                className="w-full aspect-video"
+                title="Mapa de la inmobiliaria"
+              />
             </div>
+            <Button
+              className="mt-4 bg-brand-orange hover:bg-brand-orange/90 text-white"
+              asChild
+            >
+              <a
+                href="https://www.google.com/maps/search/?api=1&query=Jorge%20Newbery%201562%2C%20Reconquista%2C%20Santa%20Fe%2C%20Argentina"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Globe className="w-4 h-4 mr-2" />
+                Ver en Google Maps
+              </a>
+            </Button>
           </motion.div>
         </div>
       </section>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -24,6 +24,7 @@ import { Badge } from "@/components/ui/badge";
 import { getOptimizedImageUrl } from "@/lib/cloudinary";
 import Link from "next/link";
 import Image from "next/image";
+import { MapThumbnail } from "@/components/MapThumbnail";
 
 // Importar servicios
 import { useIsClient } from "@/hooks/use-is-client";
@@ -903,6 +904,36 @@ export default function HomePage() {
         </div>
       </section>
 
+      {/* Map Thumbnail Section - Dirección de la inmobiliaria */}
+      <section className="py-16 bg-gray-900">
+        <div className="container mx-auto px-4">
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-8 items-center">
+            <div className="lg:col-span-1">
+              <h3 className="text-2xl font-bold text-white mb-2">Nuestra ubicación</h3>
+              <p className="text-gray-300">Jorge Newbery 1562, Reconquista, Santa Fe, Argentina</p>
+              <div className="mt-4">
+                <Link 
+                  href="https://www.google.com/maps/search/?api=1&query=Jorge%20Newbery%201562%2C%20Reconquista%2C%20Santa%20Fe%2C%20Argentina"
+                  target="_blank"
+                  className="inline-flex items-center text-brand-orange hover:text-orange-400"
+                >
+                  <span className="underline">Ver en Google Maps</span>
+                </Link>
+              </div>
+            </div>
+            <div className="lg:col-span-2">
+              <div className="relative rounded-xl overflow-hidden border border-gray-700 bg-gray-800">
+                <MapThumbnail 
+                  query="Jorge Newbery 1562, Reconquista, Santa Fe, Argentina"
+                  className="w-full aspect-video"
+                  title="Mapa de la inmobiliaria"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+ 
       {/* Footer */}
       <footer className="bg-gray-800 border-t border-gray-700 py-12">
         <div className="container mx-auto px-4">

--- a/app/propiedades/[id]/page.tsx
+++ b/app/propiedades/[id]/page.tsx
@@ -31,6 +31,7 @@ import {
   Home
 } from "lucide-react"
 import type { Property as PropertyType } from "@/lib/supabase"
+import { MapThumbnail } from "@/components/MapThumbnail"
 
 interface Property extends PropertyType {
   operation: "sale" | "rent"
@@ -407,21 +408,19 @@ export default function PropertyDetailPage() {
               <Card className="bg-gray-800 border-gray-700 mt-6">
                 <CardContent className="p-6">
                   <h3 className="text-xl font-semibold text-white mb-4">Ubicación</h3>
-                  <div className="relative h-80 rounded-lg overflow-hidden bg-gray-700 flex items-center justify-center">
-                    {/* Static map placeholder - easily replaceable with actual Google Maps */}
-                    <div className="text-center text-gray-400">
-                      <MapPin className="w-12 h-12 mx-auto mb-3 text-brand-orange" />
-                      <p className="font-medium text-white text-lg">{property.address}</p>
-                      <p className="text-gray-300">{property.neighborhood}, {property.city}</p>
-                      <p className="text-sm mt-3 text-gray-400">Mapa interactivo próximamente</p>
-                      <Button 
-                        className="mt-4 bg-brand-orange hover:bg-brand-orange/90"
-                        onClick={() => window.open(`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(`${property.address}, ${property.neighborhood}, ${property.city}`)}`)}
-                      >
-                        Ver en Google Maps
-                      </Button>
-                    </div>
+                  <div className="relative h-80 rounded-lg overflow-hidden bg-gray-700">
+                    <MapThumbnail 
+                      query={`${property.address}, ${property.neighborhood}, ${property.city}`}
+                      className="h-80"
+                      title={`Mapa de ${property.address}`}
+                    />
                   </div>
+                  <Button 
+                    className="mt-4 bg-brand-orange hover:bg-brand-orange/90"
+                    onClick={() => window.open(`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(`${property.address}, ${property.neighborhood}, ${property.city}`)}`)}
+                  >
+                    Ver en Google Maps
+                  </Button>
                 </CardContent>
               </Card>
             )}

--- a/components/MapThumbnail.tsx
+++ b/components/MapThumbnail.tsx
@@ -1,0 +1,25 @@
+import React from "react"
+
+interface MapThumbnailProps {
+  query: string
+  zoom?: number
+  className?: string
+  title?: string
+}
+
+export function MapThumbnail({ query, zoom = 16, className = "", title = "Mapa" }: MapThumbnailProps) {
+  const src = `https://www.google.com/maps?hl=es&q=${encodeURIComponent(query)}&z=${zoom}&output=embed`
+
+  return (
+    <div className={`relative overflow-hidden ${className}`}>
+      <iframe
+        src={src}
+        title={title}
+        className="absolute inset-0 w-full h-full border-0"
+        loading="lazy"
+        referrerPolicy="no-referrer-when-downgrade"
+        aria-label={title}
+      />
+    </div>
+  )
+}


### PR DESCRIPTION
Adds Google Maps thumbnails to property details, contact, and home pages to display map miniatures for relevant addresses.

---
<a href="https://cursor.com/background-agent?bcId=bc-80dad85d-e6e6-4206-9d82-e5ec27c22acb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-80dad85d-e6e6-4206-9d82-e5ec27c22acb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

